### PR TITLE
Dd g 2 - add centered banner image to overlay

### DIFF
--- a/react-client/src/components/overlay.jsx
+++ b/react-client/src/components/overlay.jsx
@@ -12,6 +12,14 @@ left: 0;
 background-color: rgb(0,0,0);
 background-color: rgba(0,0,0, 0.9);
 `
+const CenterImage = styled.img`
+  vertical-align: middle;
+  max-height: 100%;
+  max-width: 100%;
+  position: relative;
+  top: 25%;
+
+`
 
 class GalleryOverlay extends React.Component {
   constructor(props) {
@@ -21,8 +29,9 @@ class GalleryOverlay extends React.Component {
   render() {
     return(<Overlay
             overlay={this.props.overlay}
-            onClick={this.props.handleClick}
-    />)
+            onClick={this.props.handleClick}>
+            <CenterImage src={this.props.testImage}/>
+          </Overlay>)
   }
 }
 

--- a/react-client/src/components/overlay.jsx
+++ b/react-client/src/components/overlay.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import styled from 'styled-components'
+
+const Overlay = styled.div`
+height: 100%;
+width: 100%;
+display: ${props => props.overlay ? "block" : "none"};
+position: fixed;
+z-index: 1;
+top: 0;
+left: 0;
+background-color: rgb(0,0,0);
+background-color: rgba(0,0,0, 0.9);
+`
+
+class GalleryOverlay extends React.Component {
+  constructor(props) {
+    super(props)
+  }
+
+  render() {
+    return(<Overlay
+            overlay={this.props.overlay}
+            onClick={this.props.handleClick}
+    />)
+  }
+}
+
+export default GalleryOverlay

--- a/react-client/src/index.jsx
+++ b/react-client/src/index.jsx
@@ -23,17 +23,6 @@ ${Container}:hover & {
   opacity: 1;
 }
 `
-const Overlay = styled.div`
-height: 100%;
-width: 100%;
-display: ${props => props.overlay ? "block" : "none"};
-position: fixed;
-z-index: 1;
-top: 0;
-left: 0;
-background-color: rgb(0,0,0);
-background-color: rgba(0,0,0, 0.9);
-`
 const TEST_IMAGE_URL = 'https://massdrop-s3.imgix.net/product-images/massdrop-x-sennheiser-hd-58x-jubilee-headphones/FP/t9QmCD4rQEmdqhiXUZPN_AI7B6379%20copy.jpg?auto=format&fm=jpg&fit=crop&w=800&h=242.42424242424244&bg=f0f0f0&q=38&dpr=2'
 
 const MAGNIFYING_GLASS_URL = 'https://image.flaticon.com/icons/svg/181/181561.svg'
@@ -52,10 +41,6 @@ class Gallery extends React.Component {
               onClick={this.handleImageClick}/>
             <MagnifyingGlass 
               src = {MAGNIFYING_GLASS_URL}/>
-            {/* <Overlay 
-              overlay={this.state.overlay}
-              onClick={this.handleOverlayClick}>
-            </Overlay> */}
             <GalleryOverlay
               overlay={this.state.overlay}
               handleClick={this.handleOverlayClick}

--- a/react-client/src/index.jsx
+++ b/react-client/src/index.jsx
@@ -58,7 +58,8 @@ class Gallery extends React.Component {
             </Overlay> */}
             <GalleryOverlay
               overlay={this.state.overlay}
-              handleClick={this.handleOverlayClick}/>
+              handleClick={this.handleOverlayClick}
+              testImage={TEST_IMAGE_URL}/>
           </Container>)
   }
 }

--- a/react-client/src/index.jsx
+++ b/react-client/src/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDom from 'react-dom';
 import styled from 'styled-components'
+import GalleryOverlay from './components/overlay.jsx'
 
 const Container = styled.div`
 position: relative;
@@ -51,9 +52,13 @@ class Gallery extends React.Component {
               onClick={this.handleImageClick}/>
             <MagnifyingGlass 
               src = {MAGNIFYING_GLASS_URL}/>
-            <Overlay 
+            {/* <Overlay 
               overlay={this.state.overlay}
-              onClick={this.handleOverlayClick}/>
+              onClick={this.handleOverlayClick}>
+            </Overlay> */}
+            <GalleryOverlay
+              overlay={this.state.overlay}
+              handleClick={this.handleOverlayClick}/>
           </Container>)
   }
 }


### PR DESCRIPTION
![overlaytestcenterimg](https://user-images.githubusercontent.com/1518509/47468055-44f26480-d7c7-11e8-9992-a7675a03d7a9.gif)

I refactored the overlay into a new component and rendered the banner image center screen

@kennisilverio ready for code review 