### PR TITLE
Dd g 24 - CSS pt. 1 Banner Img

### DIFF
--- a/react-client/src/components/overlay.jsx
+++ b/react-client/src/components/overlay.jsx
@@ -18,6 +18,9 @@ const CarouselContainer = styled.div`
   height: 100%;
   width: 100%;
   max-width: 1300px;
+  z-index: 2;
+  background-color: rgba(0,0,0, 0.9);
+
 `
 
 const CarouselHeader = styled.div`
@@ -42,7 +45,6 @@ const CarouselImage = styled.img`
 `
 const CarouselImageWrapper = styled.div`
   -webkit-flex: 1;
-  flex: 1;
   position: fixed;
   bottom: 3%;
   width: 100%;

--- a/react-client/src/components/overlay.jsx
+++ b/react-client/src/components/overlay.jsx
@@ -12,45 +12,36 @@ const Overlay = styled.div`
   background-color: rgb(0,0,0);
   background-color: rgba(0,0,0, 0.9);
 `
-
 const CenterImage = styled.img`
   max-width: 80%;
   position: relative;
   display:block;
   margin:auto;
 `
-
-
 const BannerSpacer = styled.div`
   margin-top: 10px;
 `
-
-
 const BannerContainer = styled.div`
   position: relative;
   max-height: 20%;
   justify-content: center;
   max-height: 65vh;
 `
-
 const CenterImageWrapper = styled.span`
   width: 100%;
   position: relative;
   display: inline-block;
   box-sizing: inherit;
 `
-
 const ContentContainer = styled.div`
   position: relative;
   z-index: 1;
   box-sizing: inherit;
 `
-
 const CarouselSection = styled.section`
   padding-left: 24px;
   padding-right: 24px;  
 `
-
 const CarouselWrapper = styled.div`
   display: block;
   box-sizing: inherit;
@@ -75,21 +66,17 @@ const CarouselImageWrapper = styled.div`
   text-align: center;
   clear:both;
 `
-
 const CarouselContainer = styled.div`
   position: relative;
   height: 100%;
   width: 100%;
   max-width: 1300px;
 `
-
 const CarouselHeader = styled.div`
   padding-top: 10px;
   height: 40px;
   margin: 0 10px 10px;
 `
-
-
 const ButtonLeft = styled.input`
   z-index: 3;
   height: 10%
@@ -102,7 +89,6 @@ const ButtonLeft = styled.input`
     opacity: 0;
     }
 `
-
 const ButtonRight = styled.input`
   z-index: 3;
   height: 10%
@@ -112,7 +98,6 @@ const ButtonRight = styled.input`
   left: 92%
   transform: rotate(180deg);
 `
-
 const ButtonExit = styled.input`
   z-index: 3;
   height: 10%;
@@ -132,15 +117,8 @@ const ButtonExit = styled.input`
 // right: 0px;
 // width: 50%;
 // `
-// const Container = styled.div`
-// position: relative;
-// top: 50%;
-// left: 50%;
-// padding: 1rem;
-// `
 
 class GalleryOverlay extends React.Component {
-
   constructor(props) {
     super(props);
     this.state = {
@@ -170,9 +148,7 @@ class GalleryOverlay extends React.Component {
           <CarouselHeader>
             <ButtonExit onClick={this.props.handleClick} type="image" src="https://cdn3.iconfinder.com/data/icons/iconic-1/32/x_alt-512.png"/>
           </CarouselHeader>
-
           <ContentContainer>
-
             <BannerContainer> 
               <CenterImageWrapper>
                 <CenterImage src={this.props.imgs[this.state.centerImageIndex]}/>  
@@ -189,17 +165,12 @@ class GalleryOverlay extends React.Component {
             {/* </RightHalf> */}
 
             <CarouselSection>
-
               <CarouselImageWrapper>
                 {this.props.imgs.map((item, index, array) => {
                   return (<CarouselImage src={item}/>)
                 })}
               </CarouselImageWrapper>
-
             </CarouselSection>
-
-
-
           </ContentContainer>
         </CarouselContainer>
       </Overlay>)

--- a/react-client/src/components/overlay.jsx
+++ b/react-client/src/components/overlay.jsx
@@ -13,26 +13,47 @@ const Overlay = styled.div`
   background-color: rgba(0,0,0, 0.9);
 `
 
-const CarouselContainer = styled.div`
-  position: relative;
-  height: 100%;
-  width: 100%;
-  max-width: 1300px;
-
-
-`
-
-const CarouselHeader = styled.div`
-  padding-top: 10px;
-  height: 40px;
-  margin: 0 10px 10px;
-`
-
 const CenterImage = styled.img`
   max-width: 80%;
   position: relative;
   display:block;
   margin:auto;
+`
+
+
+const BannerSpacer = styled.div`
+  margin-top: 10px;
+`
+
+
+const BannerContainer = styled.div`
+  position: relative;
+  max-height: 20%;
+  justify-content: center;
+  max-height: 65vh;
+`
+
+const CenterImageWrapper = styled.span`
+  width: 100%;
+  position: relative;
+  display: inline-block;
+  box-sizing: inherit;
+`
+
+const ContentContainer = styled.div`
+  position: relative;
+  z-index: 1;
+  box-sizing: inherit;
+`
+
+const CarouselSection = styled.section`
+  padding-left: 24px;
+  padding-right: 24px;  
+`
+
+const CarouselWrapper = styled.div`
+  display: block;
+  box-sizing: inherit;
 `
 const CarouselImage = styled.img`
   display: inline-block
@@ -55,9 +76,19 @@ const CarouselImageWrapper = styled.div`
   clear:both;
 `
 
-const BannerSpacer = styled.div`
-  margin-top: 10px;
+const CarouselContainer = styled.div`
+  position: relative;
+  height: 100%;
+  width: 100%;
+  max-width: 1300px;
 `
+
+const CarouselHeader = styled.div`
+  padding-top: 10px;
+  height: 40px;
+  margin: 0 10px 10px;
+`
+
 
 const ButtonLeft = styled.input`
   z-index: 3;
@@ -90,40 +121,6 @@ const ButtonExit = styled.input`
   top: 5%
   left:90%
 `
-
-const BannerContainer = styled.div`
-  position: relative;
-  max-height: 20%;
-  justify-content: center;
-  max-height: 65vh;
-`
-
-const CenterImageWrapper = styled.span`
-  width: 100%;
-  position: relative;
-  display: inline-block;
-  box-sizing: inherit;
-`
-
-const ContentContainer = styled.div`
-  position: relative;
-  z-index: 1;
-  box-sizing: inherit;
-`
-
-const CarouselSection = styled.section`
-  padding-left: 24px;
-  padding-right: 24px;  
-
-`
-
-const CarouselWrapper = styled.div`
-  display: block;
-  box-sizing: inherit;
-  z-index: 2;
-  background-color: rgba(0,0,0, 0.9);
-`
-
 // const LeftHalf = styled.div`
 // position: absolute;
 // left: 0px;

--- a/react-client/src/components/overlay.jsx
+++ b/react-client/src/components/overlay.jsx
@@ -53,6 +53,11 @@ const CarouselImageWrapper = styled.div`
   text-align: center;
   clear:both;
 `
+
+const BannerSpacer = styled.div`
+  margin-top: 10px;
+`
+
 const ButtonLeft = styled.input`
   z-index: 3;
   height: 10%
@@ -85,15 +90,34 @@ const ButtonExit = styled.input`
   left:90%
 `
 
-const CenterImageWrapper = styled.div`
-  overflow: visible;
-  position: absolute;
+const BannerContainer = styled.div`
+  position: relative;
   max-height: 20%;
   justify-content: center;
+  max-height: 65vh;
+`
+
+const CenterImageWrapper = styled.span`
+  width: 100%;
+  position: relative;
+  display: inline-block;
+  box-sizing: inherit;
 `
 
 const ContentContainer = styled.div`
+  position: relative;
+  z-index: 1;
+  box-sizing: inherit;
+`
 
+const CarouselSection = styled.section`
+  padding-left: 24px;
+  padding-right: 24px;
+`
+
+const CarouselWrapper = styled.div`
+  display: block;
+  box-sizing: inherit;
 `
 
 // const LeftHalf = styled.div`
@@ -148,9 +172,12 @@ class GalleryOverlay extends React.Component {
 
           <ContentContainer>
 
-            <CenterImageWrapper>
-              <CenterImage src={this.props.imgs[this.state.centerImageIndex]}/>  
-            </CenterImageWrapper>
+            <BannerContainer> 
+              <CenterImageWrapper>
+                <CenterImage src={this.props.imgs[this.state.centerImageIndex]}/>  
+              </CenterImageWrapper>
+              <BannerSpacer/>
+            </BannerContainer>
 
             {/* <LeftHalf> */}
             <ButtonLeft onClick={this.handleLeftClick} type="image" src="https://cdn0.iconfinder.com/data/icons/basic-ui-elements-round/700/01_arrow_left-128.png"/>
@@ -160,11 +187,16 @@ class GalleryOverlay extends React.Component {
             <ButtonRight onClick={this.handleRightClick} type="image" src="https://cdn0.iconfinder.com/data/icons/basic-ui-elements-round/700/01_arrow_left-128.png"/>
             {/* </RightHalf> */}
 
-            <CarouselImageWrapper>
-              {this.props.imgs.map((item, index, array) => {
-                return (<CarouselImage src={item}/>)
-              })}
-            </CarouselImageWrapper>
+            <CarouselSection>
+
+              <CarouselImageWrapper>
+                {this.props.imgs.map((item, index, array) => {
+                  return (<CarouselImage src={item}/>)
+                })}
+              </CarouselImageWrapper>
+
+            </CarouselSection>
+
 
 
           </ContentContainer>

--- a/react-client/src/components/overlay.jsx
+++ b/react-client/src/components/overlay.jsx
@@ -92,6 +92,10 @@ const CenterImageWrapper = styled.div`
   justify-content: center;
 `
 
+const ContentContainer = styled.div`
+
+`
+
 // const LeftHalf = styled.div`
 // position: absolute;
 // left: 0px;
@@ -142,27 +146,29 @@ class GalleryOverlay extends React.Component {
             <ButtonExit onClick={this.props.handleClick} type="image" src="https://cdn3.iconfinder.com/data/icons/iconic-1/32/x_alt-512.png"/>
           </CarouselHeader>
 
-          {/* <LeftHalf> */}
-          <ButtonLeft onClick={this.handleLeftClick} type="image" src="https://cdn0.iconfinder.com/data/icons/basic-ui-elements-round/700/01_arrow_left-128.png"/>
-          {/* </LeftHalf> */}
+          <ContentContainer>
 
-          {/* <RightHalf> */}
-          <ButtonRight onClick={this.handleRightClick} type="image" src="https://cdn0.iconfinder.com/data/icons/basic-ui-elements-round/700/01_arrow_left-128.png"/>
-          {/* </RightHalf> */}
+            <CenterImageWrapper>
+              <CenterImage src={this.props.imgs[this.state.centerImageIndex]}/>  
+            </CenterImageWrapper>
 
-          <CenterImageWrapper>
-            <CenterImage src={this.props.imgs[this.state.centerImageIndex]}/>  
-          </CenterImageWrapper>
+            {/* <LeftHalf> */}
+            <ButtonLeft onClick={this.handleLeftClick} type="image" src="https://cdn0.iconfinder.com/data/icons/basic-ui-elements-round/700/01_arrow_left-128.png"/>
+            {/* </LeftHalf> */}
 
-          <CarouselImageWrapper>
-            {this.props.imgs.map((item, index, array) => {
-              return (<CarouselImage src={item}/>)
-            })}
-          </CarouselImageWrapper>
+            {/* <RightHalf> */}
+            <ButtonRight onClick={this.handleRightClick} type="image" src="https://cdn0.iconfinder.com/data/icons/basic-ui-elements-round/700/01_arrow_left-128.png"/>
+            {/* </RightHalf> */}
 
+            <CarouselImageWrapper>
+              {this.props.imgs.map((item, index, array) => {
+                return (<CarouselImage src={item}/>)
+              })}
+            </CarouselImageWrapper>
+
+
+          </ContentContainer>
         </CarouselContainer>
-
-
       </Overlay>)
   } 
 }

--- a/react-client/src/components/overlay.jsx
+++ b/react-client/src/components/overlay.jsx
@@ -4,8 +4,6 @@ import styled from 'styled-components'
 const Overlay = styled.div`
   height: 100%;
   width: 100%;
-  display: flex;
-  display: -webkit-flex;
   display: ${props => props.overlay ? "block" : "none"};
   position: fixed;
   z-index: 1;
@@ -14,15 +12,25 @@ const Overlay = styled.div`
   background-color: rgb(0,0,0);
   background-color: rgba(0,0,0, 0.9);
 `
+
+const CarouselContainer = styled.div`
+  position: relative;
+  height: 100%;
+  width: 100%;
+  max-width: 1300px;
+`
+
+const CarouselHeader = styled.div`
+  padding-top: 10px;
+  height: 40px;
+  margin: 0 10px 10px;
+`
+
 const CenterImage = styled.img`
-  vertical-align: middle;
   max-width: 80%;
-  max-height: 40%;
   position: relative;
   display:block;
   margin:auto;
-  top: 20%;
-  flex: none;
 `
 const CarouselImage = styled.img`
   display: inline-block
@@ -129,25 +137,32 @@ class GalleryOverlay extends React.Component {
   render() {
     return(
       <Overlay overlay={this.props.overlay}>
+        <CarouselContainer>
+          <CarouselHeader>
+            <ButtonExit onClick={this.props.handleClick} type="image" src="https://cdn3.iconfinder.com/data/icons/iconic-1/32/x_alt-512.png"/>
+          </CarouselHeader>
 
-        {/* <LeftHalf> */}
-        <ButtonLeft onClick={this.handleLeftClick} type="image" src="https://cdn0.iconfinder.com/data/icons/basic-ui-elements-round/700/01_arrow_left-128.png"/>
-        {/* </LeftHalf> */}
+          {/* <LeftHalf> */}
+          <ButtonLeft onClick={this.handleLeftClick} type="image" src="https://cdn0.iconfinder.com/data/icons/basic-ui-elements-round/700/01_arrow_left-128.png"/>
+          {/* </LeftHalf> */}
 
-        {/* <RightHalf> */}
-        <ButtonRight onClick={this.handleRightClick} type="image" src="https://cdn0.iconfinder.com/data/icons/basic-ui-elements-round/700/01_arrow_left-128.png"/>
-        {/* </RightHalf> */}
+          {/* <RightHalf> */}
+          <ButtonRight onClick={this.handleRightClick} type="image" src="https://cdn0.iconfinder.com/data/icons/basic-ui-elements-round/700/01_arrow_left-128.png"/>
+          {/* </RightHalf> */}
 
-        <ButtonExit onClick={this.props.handleClick} type="image" src="https://cdn3.iconfinder.com/data/icons/iconic-1/32/x_alt-512.png"/>
-        <CenterImageWrapper>
-          <CenterImage src={this.props.imgs[this.state.centerImageIndex]}/>  
-        </CenterImageWrapper>
+          <CenterImageWrapper>
+            <CenterImage src={this.props.imgs[this.state.centerImageIndex]}/>  
+          </CenterImageWrapper>
 
-        <CarouselImageWrapper>
-          {this.props.imgs.map((item, index, array) => {
-            return (<CarouselImage src={item}/>)
-          })}
-        </CarouselImageWrapper>
+          <CarouselImageWrapper>
+            {this.props.imgs.map((item, index, array) => {
+              return (<CarouselImage src={item}/>)
+            })}
+          </CarouselImageWrapper>
+
+        </CarouselContainer>
+
+
       </Overlay>)
   } 
 }

--- a/react-client/src/components/overlay.jsx
+++ b/react-client/src/components/overlay.jsx
@@ -18,8 +18,7 @@ const CarouselContainer = styled.div`
   height: 100%;
   width: 100%;
   max-width: 1300px;
-  z-index: 2;
-  background-color: rgba(0,0,0, 0.9);
+
 
 `
 
@@ -114,12 +113,15 @@ const ContentContainer = styled.div`
 
 const CarouselSection = styled.section`
   padding-left: 24px;
-  padding-right: 24px;
+  padding-right: 24px;  
+
 `
 
 const CarouselWrapper = styled.div`
   display: block;
   box-sizing: inherit;
+  z-index: 2;
+  background-color: rgba(0,0,0, 0.9);
 `
 
 // const LeftHalf = styled.div`


### PR DESCRIPTION
dd-g-27 will continue this css revamp. 

This ticket involved matching the structure and styling of massdrop's product overlay

A lot has been added, but the overall structure should be re evaluated

The banner image section is in good shape, the carousel still has a few problems to be addressed later in dd-g-27
<img width="1440" alt="screenshot 2018-10-31 15 31 46" src="https://user-images.githubusercontent.com/1518509/47813674-225dcf80-dd22-11e8-997d-bab9f548d95c.png">
