### PR TITLE
Dd g 17 - seeding db with final products, using ProductGallery cpt, adding 404 handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@
 ## $ npm run react-dev
 
 # Seed Local MongoDB
-## databse >> deltaDrop
-## collection >> products
+## databse: deltaDrop
+## collection: products
 ## $ npm run seed

--- a/db/index.js
+++ b/db/index.js
@@ -33,11 +33,15 @@ const createProductRecord = (json, cb) => {
 const getProductRecord = (name, cb) => {
   Product.findOne({productName: name}).exec((err, data) => {
     if(err) cb(err, null)
-    const payload = {
-      bannerImageUrl: data.bannerImageUrl, 
-      images: data.productImageUrls
+    else if(!data) {
+      cb(new Error('404'), null)
+    } else {
+      const payload = {
+        bannerImageUrl: data.bannerImageUrl, 
+        images: data.productImageUrls
+      }
+      cb(null, payload)
     }
-    cb(null, payload)
   });
 }
 

--- a/db/index.js
+++ b/db/index.js
@@ -31,18 +31,22 @@ const createProductRecord = (json, cb) => {
 }
 
 const getProductRecord = (name, cb) => {
-  Product.findOne({productName: name}).exec((err, data) => {
-    if(err) cb(err, null)
-    else if(!data) {
-      cb(new Error('404'), null)
-    } else {
-      const payload = {
-        bannerImageUrl: data.bannerImageUrl, 
-        images: data.productImageUrls
+  try {
+    Product.findOne({productName: name}).exec((err, data) => {
+      if(err) cb(err, null)
+      else if(!data) {
+        cb(new Error('404'), null)
+      } else {
+        const payload = {
+          bannerImageUrl: data.bannerImageUrl, 
+          images: data.productImageUrls
+        }
+        cb(null, payload)
       }
-      cb(null, payload)
-    }
-  });
+    });
+  } catch (err) {
+    cb(err);
+  }
 }
 
 exports.createProductRecord = createProductRecord;

--- a/db/index.js
+++ b/db/index.js
@@ -45,7 +45,7 @@ const getProductRecord = (name, cb) => {
       }
     });
   } catch (err) {
-    cb(err);
+    cb(err, null);
   }
 }
 

--- a/db/index.js
+++ b/db/index.js
@@ -31,18 +31,18 @@ const createProductRecord = (json, cb) => {
 }
 
 const getProductRecord = (name, cb) => {
-    Product.findOne({productName: name}).exec((err, data) => {
-      if(err) cb(err, null)
-      else if(!data) {
-        cb(new Error('404'), null)
-      } else {
-        const payload = {
-          bannerImageUrl: data.bannerImageUrl, 
-          images: data.productImageUrls
-        }
-        cb(null, payload)
+  Product.findOne({productName: name}).exec((err, data) => {
+    if(err) cb(err, null)
+    else if(!data) {
+      cb(new Error('404'), null)
+    } else {
+      const payload = {
+        bannerImageUrl: data.bannerImageUrl, 
+        images: data.productImageUrls
       }
-    });
+      cb(null, payload)
+    }
+  });
 }
 
 exports.createProductRecord = createProductRecord;

--- a/db/index.js
+++ b/db/index.js
@@ -31,7 +31,6 @@ const createProductRecord = (json, cb) => {
 }
 
 const getProductRecord = (name, cb) => {
-  try {
     Product.findOne({productName: name}).exec((err, data) => {
       if(err) cb(err, null)
       else if(!data) {
@@ -44,9 +43,6 @@ const getProductRecord = (name, cb) => {
         cb(null, payload)
       }
     });
-  } catch (err) {
-    cb(err, null);
-  }
 }
 
 exports.createProductRecord = createProductRecord;

--- a/react-client/dist/index.html
+++ b/react-client/dist/index.html
@@ -6,6 +6,6 @@
 </head>
 <body>
 <div id="gallery"></div>
-<script type="text/javascript" src="gallery.bundle.js"></script>
+<script type="text/javascript" src="http://127.0.0.1:3000/gallery.bundle.js"></script>
 </body>
 </html>

--- a/react-client/src/components/Gallery.jsx
+++ b/react-client/src/components/Gallery.jsx
@@ -36,6 +36,7 @@ class Gallery extends React.Component {
     this.state = { 
       overlay: false,
     }
+    
     this.handleImageClick = () => this.setState({ overlay: true })
     this.handleOverlayClick = () => this.setState({ overlay: false})
   }

--- a/react-client/src/components/Gallery.jsx
+++ b/react-client/src/components/Gallery.jsx
@@ -52,7 +52,7 @@ class Gallery extends React.Component {
           overlay={this.state.overlay}
           handleClick={this.handleOverlayClick}
           src={this.props.src}
-          imgs={[this.props.src, ...this.props.imgs] || [this.props.src] || []}/>
+          imgs={[this.props.src, ...this.props.imgs]}/>
       </Container>
     )
   }

--- a/react-client/src/components/ProductGallery.jsx
+++ b/react-client/src/components/ProductGallery.jsx
@@ -3,17 +3,26 @@ import React from 'react';
 import Gallery from './Gallery.jsx';
 import axios from 'axios';
 
+import styled from 'styled-components';
 // ProductGallery is specialized component which will provide the lead banner image for a product, to be featured on each product page
 
 // It gets all data for the db via ProductName.  It expects product.bannerImage and an array of images associated w the product
+
+const NotFound = styled.div`
+  display: ${props => props.fourOhFour ? "block" : "none"};
+`
+
 class ProductGallery extends React.Component {
   constructor(props) {
     super(props);
+
+    
     this.state = { 
       bannerImg: '',
       carouselImgs: [],
-      fourOhFour: 'none'
+      fourOhFour: false
     }
+ 
   }
 
   componentDidMount() {
@@ -27,23 +36,26 @@ class ProductGallery extends React.Component {
     .then(res => {
       this.setState({
         bannerImg: res.data.bannerImageUrl,
-        carouselImgs: res.data.images.split(',')
+        carouselImgs: res.data.images.split(','),
+        fourOhFour: false
       })
+      console.log(this.state.fourOhFour)
     })
     .catch(err => {
       if (err.message === 'Request failed with status code 404') {
         this.setState({
-          fourOhFour: 'block'
+          fourOhFour: true
         })
       }
     })
   }
 
   render() {
+
     return (
       <div>
         <Gallery src={this.state.bannerImg} imgs={this.state.carouselImgs}/>
-        <div styles={{ display: this.state.fourOhFour }}>Not Found - Please Try Another Product</div>
+        <NotFound fourOhFour={this.state.fourOhFour}>Not Found - Please Try Another Product</NotFound>
       </div>
     );
   }

--- a/react-client/src/components/ProductGallery.jsx
+++ b/react-client/src/components/ProductGallery.jsx
@@ -8,7 +8,6 @@ import axios from 'axios';
 // It gets all data for the db via ProductName.  It expects product.bannerImage and an array of images associated w the product
 class ProductGallery extends React.Component {
   constructor(props) {
-    console.log('product gallery constructor')
     super(props);
     this.state = { 
       bannerImg: '',
@@ -16,8 +15,6 @@ class ProductGallery extends React.Component {
       fourOhFour: 'none'
     }
   }
-
-
 
   componentDidMount() {
     let url = new URL(window.location.href)
@@ -28,12 +25,12 @@ class ProductGallery extends React.Component {
     
     axios.get('/productImages/' + productName)
     .then(res => {
-      console.log(res.data);
       this.setState({
         bannerImg: res.data.bannerImageUrl,
         carouselImgs: res.data.images.split(',')
       })
-    }).catch(err => {
+    })
+    .catch(err => {
       if (err.message === 'Request failed with status code 404') {
         this.setState({
           fourOhFour: 'block'
@@ -46,7 +43,7 @@ class ProductGallery extends React.Component {
     return (
       <div>
         <Gallery src={this.state.bannerImg} imgs={this.state.carouselImgs}/>
-        <div styles={{ display: this.state.fourOhFour }}>404 Not Found</div>
+        <div styles={{ display: this.state.fourOhFour }}>Not Found - Please Try Another Product</div>
       </div>
     );
   }

--- a/react-client/src/components/ProductGallery.jsx
+++ b/react-client/src/components/ProductGallery.jsx
@@ -43,7 +43,6 @@ class ProductGallery extends React.Component {
   }
 
   render() {
-
     return (
       <div>
         <Gallery src={this.state.bannerImg} imgs={this.state.carouselImgs}/>

--- a/react-client/src/components/ProductGallery.jsx
+++ b/react-client/src/components/ProductGallery.jsx
@@ -18,7 +18,7 @@ class ProductGallery extends React.Component {
   componentDidMount() {
     let url = new URL(window.location.href)
     let productName = 'test1'
-    if (url.pathname !== '/') productName = url.pathname.split('/')[1]
+    if (url.pathname !== '/') productName = url.pathname.split('/')[url.pathname.split('/') - 1]
 
     axios.get('/productImages/' + productName)
     .then(res => {

--- a/react-client/src/components/ProductGallery.jsx
+++ b/react-client/src/components/ProductGallery.jsx
@@ -25,8 +25,6 @@ class ProductGallery extends React.Component {
     
     axios.get('/productImages/' + productName)
     .then(res => {
-      // let json = JSON.parse(res.data);
-      console.log('HI')
       console.log(res.data);
       this.setState({
         bannerImg: res.data.bannerImageUrl,

--- a/react-client/src/components/ProductGallery.jsx
+++ b/react-client/src/components/ProductGallery.jsx
@@ -30,7 +30,7 @@ class ProductGallery extends React.Component {
       console.log(res.data);
       this.setState({
         bannerImg: res.data.bannerImageUrl,
-        carouselImgs: [res.data.images]
+        carouselImgs: res.data.images.split(',')
       })
     })
   }

--- a/react-client/src/components/ProductGallery.jsx
+++ b/react-client/src/components/ProductGallery.jsx
@@ -8,20 +8,26 @@ import axios from 'axios';
 // It gets all data for the db via ProductName.  It expects product.bannerImage and an array of images associated w the product
 class ProductGallery extends React.Component {
   constructor(props) {
+    console.log('product gallery constructor')
     super(props);
     this.state = { 
-      bannerImg: null,
-      carouselImgs: null
+      bannerImg: '',
+      carouselImgs: []
     }
   }
 
   componentDidMount() {
     let url = new URL(window.location.href)
     let productName = 'test1'
-    if (url.pathname !== '/') productName = url.pathname.split('/')[url.pathname.split('/') - 1]
-
+    if (url.pathname !== '/') {
+      productName = url.pathname.split('/')[2]
+    }
+    
     axios.get('/productImages/' + productName)
     .then(res => {
+      // let json = JSON.parse(res.data);
+      console.log('HI')
+      console.log(res.data);
       this.setState({
         bannerImg: res.data.bannerImageUrl,
         carouselImgs: [res.data.images]

--- a/react-client/src/components/ProductGallery.jsx
+++ b/react-client/src/components/ProductGallery.jsx
@@ -12,9 +12,12 @@ class ProductGallery extends React.Component {
     super(props);
     this.state = { 
       bannerImg: '',
-      carouselImgs: []
+      carouselImgs: [],
+      fourOhFour: 'none'
     }
   }
+
+
 
   componentDidMount() {
     let url = new URL(window.location.href)
@@ -30,12 +33,21 @@ class ProductGallery extends React.Component {
         bannerImg: res.data.bannerImageUrl,
         carouselImgs: res.data.images.split(',')
       })
+    }).catch(err => {
+      if (err.message === 'Request failed with status code 404') {
+        this.setState({
+          fourOhFour: 'block'
+        })
+      }
     })
   }
 
   render() {
     return (
-      <Gallery src={this.state.bannerImg} imgs={this.state.carouselImgs}/>
+      <div>
+        <Gallery src={this.state.bannerImg} imgs={this.state.carouselImgs}/>
+        <div styles={{ display: this.state.fourOhFour }}>404 Not Found</div>
+      </div>
     );
   }
 }

--- a/react-client/src/components/ProductGallery.jsx
+++ b/react-client/src/components/ProductGallery.jsx
@@ -39,7 +39,6 @@ class ProductGallery extends React.Component {
         carouselImgs: res.data.images.split(','),
         fourOhFour: false
       })
-      console.log(this.state.fourOhFour)
     })
     .catch(err => {
       if (err.message === 'Request failed with status code 404') {

--- a/react-client/src/components/ProductGallery.jsx
+++ b/react-client/src/components/ProductGallery.jsx
@@ -2,11 +2,7 @@
 import React from 'react';
 import Gallery from './Gallery.jsx';
 import axios from 'axios';
-
 import styled from 'styled-components';
-// ProductGallery is specialized component which will provide the lead banner image for a product, to be featured on each product page
-
-// It gets all data for the db via ProductName.  It expects product.bannerImage and an array of images associated w the product
 
 const NotFound = styled.div`
   display: ${props => props.fourOhFour ? "block" : "none"};
@@ -15,14 +11,11 @@ const NotFound = styled.div`
 class ProductGallery extends React.Component {
   constructor(props) {
     super(props);
-
-    
     this.state = { 
       bannerImg: '',
       carouselImgs: [],
       fourOhFour: false
     }
- 
   }
 
   componentDidMount() {

--- a/react-client/src/components/overlay.jsx
+++ b/react-client/src/components/overlay.jsx
@@ -130,7 +130,6 @@ class GalleryOverlay extends React.Component {
   }
 
   handleRightClick(e) {
-    console.log(this.props)
     let i = this.state.centerImageIndex;
     if (i < this.props.imgs.length - 1) i++;
     this.setState({ centerImageIndex: i })

--- a/react-client/src/components/overlay.jsx
+++ b/react-client/src/components/overlay.jsx
@@ -167,7 +167,7 @@ class GalleryOverlay extends React.Component {
             <CarouselSection>
               <CarouselImageWrapper>
                 {this.props.imgs.map((item, index, array) => {
-                  return (<CarouselImage src={item}/>)
+                  return (<CarouselImage key={index} src={item}/>)
                 })}
               </CarouselImageWrapper>
             </CarouselSection>

--- a/react-client/src/components/overlay.jsx
+++ b/react-client/src/components/overlay.jsx
@@ -130,8 +130,9 @@ class GalleryOverlay extends React.Component {
   }
 
   handleRightClick(e) {
+    console.log(this.props)
     let i = this.state.centerImageIndex;
-    if (i < this.state.numImgs - 1) i++;
+    if (i < this.props.imgs.length - 1) i++;
     this.setState({ centerImageIndex: i })
   }
 

--- a/react-client/src/components/overlay.jsx
+++ b/react-client/src/components/overlay.jsx
@@ -87,7 +87,7 @@ const ButtonLeft = styled.input`
   opacity: 1;
   ${CarouselImageWrapper}:hover & {
     opacity: 0;
-    }
+  }
 `
 const ButtonRight = styled.input`
   z-index: 3;

--- a/react-client/src/index.jsx
+++ b/react-client/src/index.jsx
@@ -3,21 +3,9 @@ import ReactDom from 'react-dom';
 import Gallery from './components/Gallery.jsx';
 import ProductGallery from './components/ProductGallery.jsx';
 
-const SAMPLE_IMG_0 = 'https://www.cats.org.uk/uploads/branches/1/42847%20Cats%20Weekly%20Lottery%20Web%20Banner.jpg'
-const SAMPLE_IMG_1 = 'https://images.pexels.com/photos/45170/kittens-cat-cat-puppy-rush-45170.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260'
-const SAMPLE_IMG_2 = 'https://images.pexels.com/photos/65006/pexels-photo-65006.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260'
-const SAMPLE_IMG_3 = 'https://images.pexels.com/photos/9413/animal-cute-kitten-cat.jpg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260'
-const SAMPLE_IMG_4 = 'https://images.pexels.com/photos/171227/pexels-photo-171227.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260'
-const SAMPLE_IMG_5 = 'https://images.pexels.com/photos/74177/cat-74177.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260'
-
 const GalleryContainer = () => {
   return(<div>
     <ProductGallery/>
-    {/* <Gallery src={SAMPLE_IMG_1} imgs={[SAMPLE_IMG_0, SAMPLE_IMG_2, SAMPLE_IMG_5, SAMPLE_IMG_4]} /> */}
-    {/* <Gallery src={SAMPLE_IMG_2}/>
-    <Gallery src={SAMPLE_IMG_3}/>
-    <Gallery src={SAMPLE_IMG_4}/>
-    <Gallery src={SAMPLE_IMG_5}/> */}
   </div>)
 }
 

--- a/react-client/src/index.jsx
+++ b/react-client/src/index.jsx
@@ -12,8 +12,8 @@ const SAMPLE_IMG_5 = 'https://images.pexels.com/photos/74177/cat-74177.jpeg?auto
 
 const GalleryContainer = () => {
   return(<div>
-    {/* <ProductGallery/> */}
-    <Gallery src={SAMPLE_IMG_1} imgs={[SAMPLE_IMG_0, SAMPLE_IMG_2, SAMPLE_IMG_5, SAMPLE_IMG_4]} />
+    <ProductGallery/>
+    {/* <Gallery src={SAMPLE_IMG_1} imgs={[SAMPLE_IMG_0, SAMPLE_IMG_2, SAMPLE_IMG_5, SAMPLE_IMG_4]} /> */}
     {/* <Gallery src={SAMPLE_IMG_2}/>
     <Gallery src={SAMPLE_IMG_3}/>
     <Gallery src={SAMPLE_IMG_4}/>

--- a/react-client/src/index.jsx
+++ b/react-client/src/index.jsx
@@ -12,8 +12,8 @@ const SAMPLE_IMG_5 = 'https://images.pexels.com/photos/74177/cat-74177.jpeg?auto
 
 const GalleryContainer = () => {
   return(<div>
-    <ProductGallery/>
-    {/* <Gallery src={SAMPLE_IMG_1} imgs={[SAMPLE_IMG_0, SAMPLE_IMG_2, SAMPLE_IMG_5, SAMPLE_IMG_4]} /> */}
+    {/* <ProductGallery/> */}
+    <Gallery src={SAMPLE_IMG_1} imgs={[SAMPLE_IMG_0, SAMPLE_IMG_2, SAMPLE_IMG_5, SAMPLE_IMG_4]} />
     {/* <Gallery src={SAMPLE_IMG_2}/>
     <Gallery src={SAMPLE_IMG_3}/>
     <Gallery src={SAMPLE_IMG_4}/>

--- a/seed.js
+++ b/seed.js
@@ -8,15 +8,15 @@ let giveMeCats = require('./server/testJson.js').giveMeCats;
 
 let test = require('./server/testJson.js');
 
-for(let i = 0; i < NUM_RECORDS; i++) {
-  db.createProductRecord(giveMeCats('test' + i) ,(err, result) => {
-    if(err) { 
-      console.log('ERROR there are likely duplicate entries'); 
-    } else {
-      console.log('creating product test' + i);
-    }
-  })
-}
+// for(let i = 0; i < NUM_RECORDS; i++) {
+//   db.createProductRecord(giveMeCats('test' + i) ,(err, result) => {
+//     if(err) { 
+//       console.log('ERROR there are likely duplicate entries'); 
+//     } else {
+//       console.log('creating product test' + i);
+//     }
+//   })
+// }
 
 db.createProductRecord(test.giveMeCats('cats') ,(err, result) => {
   if(err) { 

--- a/seed.js
+++ b/seed.js
@@ -6,6 +6,8 @@ let db = require('./db/index.js');
 
 let giveMeCats = require('./server/testJson.js').giveMeCats;
 
+let test = require('./server/testJson.js');
+
 for(let i = 0; i < NUM_RECORDS; i++) {
   db.createProductRecord(giveMeCats('test' + i) ,(err, result) => {
     if(err) { 
@@ -15,5 +17,61 @@ for(let i = 0; i < NUM_RECORDS; i++) {
     }
   })
 }
+
+db.createProductRecord(test.giveMeCats('cats') ,(err, result) => {
+  if(err) { 
+    console.log('ERROR there are likely duplicate entries'); 
+  } else {
+    console.log('creating product test' + i);
+  }
+})
+
+db.createProductRecord(test.giveMeDogs('dogs') ,(err, result) => {
+  if(err) { 
+    console.log('ERROR there are likely duplicate entries'); 
+  } else {
+    console.log('creating product test' + i);
+  }
+})
+
+db.createProductRecord(test.giveMeFlashlight('flashlight') ,(err, result) => {
+  if(err) { 
+    console.log('ERROR there are likely duplicate entries'); 
+  } else {
+    console.log('creating product test' + i);
+  }
+})
+
+db.createProductRecord(test.giveMeHeadphones('headphones') ,(err, result) => {
+  if(err) { 
+    console.log('ERROR there are likely duplicate entries'); 
+  } else {
+    console.log('creating product test' + i);
+  }
+})
+
+db.createProductRecord(test.giveMeSeki('seki-kit') ,(err, result) => {
+  if(err) { 
+    console.log('ERROR there are likely duplicate entries'); 
+  } else {
+    console.log('creating product test' + i);
+  }
+})
+
+db.createProductRecord(test.giveMeKeyboard('keyboard') ,(err, result) => {
+  if(err) { 
+    console.log('ERROR there are likely duplicate entries'); 
+  } else {
+    console.log('creating product test' + i);
+  }
+})
+
+db.createProductRecord(test.giveMeWatches('watch') ,(err, result) => {
+  if(err) { 
+    console.log('ERROR there are likely duplicate entries'); 
+  } else {
+    console.log('creating product test' + i);
+  }
+})
 
 setTimeout(process.exit, 1000)

--- a/seed.js
+++ b/seed.js
@@ -8,15 +8,15 @@ let giveMeCats = require('./server/testJson.js').giveMeCats;
 
 let test = require('./server/testJson.js');
 
-// for(let i = 0; i < NUM_RECORDS; i++) {
-//   db.createProductRecord(giveMeCats('test' + i) ,(err, result) => {
-//     if(err) { 
-//       console.log('ERROR there are likely duplicate entries'); 
-//     } else {
-//       console.log('creating product test' + i);
-//     }
-//   })
-// }
+for(let i = 0; i < NUM_RECORDS; i++) {
+  db.createProductRecord(giveMeCats('test' + i) ,(err, result) => {
+    if(err) { 
+      console.log('ERROR there are likely duplicate entries'); 
+    } else {
+      console.log('creating product test' + i);
+    }
+  })
+}
 
 db.createProductRecord(test.giveMeCats('cats') ,(err, result) => {
   if(err) { 

--- a/seed.js
+++ b/seed.js
@@ -22,7 +22,7 @@ db.createProductRecord(test.giveMeCats('cats') ,(err, result) => {
   if(err) { 
     console.log('ERROR there are likely duplicate entries'); 
   } else {
-    console.log('creating product test' + i);
+    console.log('creating product cats');
   }
 })
 
@@ -30,7 +30,7 @@ db.createProductRecord(test.giveMeDogs('dogs') ,(err, result) => {
   if(err) { 
     console.log('ERROR there are likely duplicate entries'); 
   } else {
-    console.log('creating product test' + i);
+    console.log('creating product dogs');
   }
 })
 
@@ -38,7 +38,7 @@ db.createProductRecord(test.giveMeFlashlight('flashlight') ,(err, result) => {
   if(err) { 
     console.log('ERROR there are likely duplicate entries'); 
   } else {
-    console.log('creating product test' + i);
+    console.log('creating product flashlight');
   }
 })
 
@@ -46,7 +46,7 @@ db.createProductRecord(test.giveMeHeadphones('headphones') ,(err, result) => {
   if(err) { 
     console.log('ERROR there are likely duplicate entries'); 
   } else {
-    console.log('creating product test' + i);
+    console.log('creating product headphones');
   }
 })
 
@@ -54,7 +54,7 @@ db.createProductRecord(test.giveMeSeki('seki-kit') ,(err, result) => {
   if(err) { 
     console.log('ERROR there are likely duplicate entries'); 
   } else {
-    console.log('creating product test' + i);
+    console.log('creating product seki-kit');
   }
 })
 
@@ -62,7 +62,7 @@ db.createProductRecord(test.giveMeKeyboard('keyboard') ,(err, result) => {
   if(err) { 
     console.log('ERROR there are likely duplicate entries'); 
   } else {
-    console.log('creating product test' + i);
+    console.log('creating product keyboard');
   }
 })
 
@@ -70,7 +70,7 @@ db.createProductRecord(test.giveMeWatches('watch') ,(err, result) => {
   if(err) { 
     console.log('ERROR there are likely duplicate entries'); 
   } else {
-    console.log('creating product test' + i);
+    console.log('creating product watch');
   }
 })
 

--- a/server/index.js
+++ b/server/index.js
@@ -15,16 +15,16 @@ app.get('/buy/:productName', (req, res) => {
 })
  
 app.get('/productImages/:productName', (req,res) => {
-    let productName = req.url.split('/')[2]
-    db.getProductRecord(productName, (err, data) => {
-      if(err) {
-        if (err.message === '404') res.status(404).send(err)
-        else res.status(500).send(err)
-      }
-      else {
-        res.send(data)
-      }
-    })
+  let productName = req.url.split('/')[2]
+  db.getProductRecord(productName, (err, data) => {
+    if(err) {
+      if (err.message === '404') res.status(404).send(err)
+      else res.status(500).send(err)
+    }
+    else {
+      res.send(data)
+    }
+  })
 })
 
 // use to generate test data. productName must be unique

--- a/server/index.js
+++ b/server/index.js
@@ -17,6 +17,10 @@ app.get('/:productName', (req, res) => {
   res.sendFile(path.resolve('react-client/dist/index.html'))
 })
 
+app.get('/buy/:productName', (req, res) => {
+  res.sendFile(path.resolve('react-client/dist/index.html'))
+})
+
 app.get('/productImages', (req, res) => {
   const dummyImages = { 
     bannerImageUrl: BANNER_IMG,

--- a/server/index.js
+++ b/server/index.js
@@ -10,9 +10,6 @@ app.use(express.static(__dirname + '/../react-client/dist'));
 
 app.use(parser.json());
 
-const BANNER_IMG = 'https://massdrop-s3.imgix.net/product-images/massdrop-x-sennheiser-hd-58x-jubilee-headphones/FP/t9QmCD4rQEmdqhiXUZPN_AI7B6379%20copy.jpg?auto=format&fm=jpg&fit=crop&w=800&h=242.42424242424244&bg=f0f0f0&q=38&dpr=2'
-const CAROUSEL_IMG_URL = 'https://massdrop-s3.imgix.net/product-images/massdrop-x-sennheiser-hd-58x-jubilee-headphones/FP/UbUHmV3QPiZTK3nHpAHJ_361A2108.jpg?auto=format&fm=jpg&fit=crop&w=473&bg=f0f0f0&dpr=2'
-
 app.get('/buy/:productName', (req, res) => {
   res.sendFile(path.resolve('react-client/dist/index.html'))
 })

--- a/server/index.js
+++ b/server/index.js
@@ -30,7 +30,6 @@ app.get('/buy/:productName', (req, res) => {
 // })
 
 app.get('/productImages/:productName', (req,res) => {
-  try {
     let productName = req.url.split('/')[2]
     db.getProductRecord(productName, (err, data) => {
       if(err) {
@@ -39,9 +38,6 @@ app.get('/productImages/:productName', (req,res) => {
       }
       else res.send(data)
     })
-  } catch(err) {
-    res.status(500).send(err);
-  }
 })
 
 // use to generate test data. productName must be unique

--- a/server/index.js
+++ b/server/index.js
@@ -13,27 +13,30 @@ app.use(parser.json());
 const BANNER_IMG = 'https://massdrop-s3.imgix.net/product-images/massdrop-x-sennheiser-hd-58x-jubilee-headphones/FP/t9QmCD4rQEmdqhiXUZPN_AI7B6379%20copy.jpg?auto=format&fm=jpg&fit=crop&w=800&h=242.42424242424244&bg=f0f0f0&q=38&dpr=2'
 const CAROUSEL_IMG_URL = 'https://massdrop-s3.imgix.net/product-images/massdrop-x-sennheiser-hd-58x-jubilee-headphones/FP/UbUHmV3QPiZTK3nHpAHJ_361A2108.jpg?auto=format&fm=jpg&fit=crop&w=473&bg=f0f0f0&dpr=2'
 
-app.get('/:productName', (req, res) => {
-  res.sendFile(path.resolve('react-client/dist/index.html'))
-})
+// app.get('/:productName', (req, res) => {
+//   res.sendFile(path.resolve('react-client/dist/index.html'))
+// })
 
 app.get('/buy/:productName', (req, res) => {
   res.sendFile(path.resolve('react-client/dist/index.html'))
 })
 
-app.get('/productImages', (req, res) => {
-  const dummyImages = { 
-    bannerImageUrl: BANNER_IMG,
-    images: [CAROUSEL_IMG_URL, BANNER_IMG, BANNER_IMG]
-  }
-  res.send(JSON.stringify(dummyImages))
-})
+// app.get('/productImages', (req, res) => {
+//   const dummyImages = { 
+//     bannerImageUrl: BANNER_IMG,
+//     images: [CAROUSEL_IMG_URL, BANNER_IMG, BANNER_IMG]
+//   }
+//   res.send(JSON.stringify(dummyImages))
+// })
 
 app.get('/productImages/:productName', (req,res) => {
   try {
     let productName = req.url.split('/')[2]
     db.getProductRecord(productName, (err, data) => {
-      if(err) res.status(500).send(err)
+      if(err) {
+        if (err.message === '404') res.status(404).send(err)
+        res.status(500).send(err)
+      }
       else res.send(data)
     })
   } catch(err) {
@@ -44,14 +47,13 @@ app.get('/productImages/:productName', (req,res) => {
 // use to generate test data. productName must be unique
 // find test data in testJson.js
 app.post('/productImages', (req, res) => {
-  try {
     db.createProductRecord(req.body, (err, record) => {
-      if (err) res.status(500).send(err)
+      if (err) {
+        console.log(err)
+        res.status(500).send(err)
+      }
       else res.send(record)
     });
-  } catch (err) {
-    res.status(500).send(err)
-  }
 })
 
 app.listen(3000, () => {

--- a/server/index.js
+++ b/server/index.js
@@ -13,21 +13,9 @@ app.use(parser.json());
 const BANNER_IMG = 'https://massdrop-s3.imgix.net/product-images/massdrop-x-sennheiser-hd-58x-jubilee-headphones/FP/t9QmCD4rQEmdqhiXUZPN_AI7B6379%20copy.jpg?auto=format&fm=jpg&fit=crop&w=800&h=242.42424242424244&bg=f0f0f0&q=38&dpr=2'
 const CAROUSEL_IMG_URL = 'https://massdrop-s3.imgix.net/product-images/massdrop-x-sennheiser-hd-58x-jubilee-headphones/FP/UbUHmV3QPiZTK3nHpAHJ_361A2108.jpg?auto=format&fm=jpg&fit=crop&w=473&bg=f0f0f0&dpr=2'
 
-// app.get('/:productName', (req, res) => {
-//   res.sendFile(path.resolve('react-client/dist/index.html'))
-// })
-
 app.get('/buy/:productName', (req, res) => {
   res.sendFile(path.resolve('react-client/dist/index.html'))
 })
-
-// app.get('/productImages', (req, res) => {
-//   const dummyImages = { 
-//     bannerImageUrl: BANNER_IMG,
-//     images: [CAROUSEL_IMG_URL, BANNER_IMG, BANNER_IMG]
-//   }
-//   res.send(JSON.stringify(dummyImages))
-// })
 
 app.get('/productImages/:productName', (req,res) => {
     let productName = req.url.split('/')[2]
@@ -36,7 +24,10 @@ app.get('/productImages/:productName', (req,res) => {
         if (err.message === '404') res.status(404).send(err)
         res.status(500).send(err)
       }
-      else res.send(data)
+      else {
+        console.log(data);
+        res.send(data)
+      }
     })
 })
 

--- a/server/index.js
+++ b/server/index.js
@@ -16,13 +16,13 @@ const CAROUSEL_IMG_URL = 'https://massdrop-s3.imgix.net/product-images/massdrop-
 app.get('/buy/:productName', (req, res) => {
   res.sendFile(path.resolve('react-client/dist/index.html'))
 })
-
+ 
 app.get('/productImages/:productName', (req,res) => {
     let productName = req.url.split('/')[2]
     db.getProductRecord(productName, (err, data) => {
       if(err) {
         if (err.message === '404') res.status(404).send(err)
-        res.status(500).send(err)
+        else res.status(500).send(err)
       }
       else {
         res.send(data)

--- a/server/index.js
+++ b/server/index.js
@@ -30,13 +30,13 @@ app.get('/productImages/:productName', (req,res) => {
 // use to generate test data. productName must be unique
 // find test data in testJson.js
 app.post('/productImages', (req, res) => {
-    db.createProductRecord(req.body, (err, record) => {
-      if (err) {
-        console.log(err)
-        res.status(500).send(err)
-      }
-      else res.send(record)
-    });
+  db.createProductRecord(req.body, (err, record) => {
+    if (err) {
+      console.log(err)
+      res.status(500).send(err)
+    }
+    else res.send(record)
+  });
 })
 
 app.listen(3000, () => {

--- a/server/index.js
+++ b/server/index.js
@@ -25,7 +25,6 @@ app.get('/productImages/:productName', (req,res) => {
         res.status(500).send(err)
       }
       else {
-        console.log(data);
         res.send(data)
       }
     })

--- a/server/testJson.js
+++ b/server/testJson.js
@@ -1,40 +1,75 @@
 module.exports.giveMeFlashlight = (productName) => {
   return {
     "productName": productName,
-    "bannerImageUrl": "",
-	  "productImageUrls": ["", "", "", ""]
+    "bannerImageUrl": "https://massdrop-s3.imgix.net/product-images/nitecore-ec22-1000-lumen-infinite-led-flashlight/FP/PAHNdxJRHeuuutzQqqs7_banner.jpg?auto=format&fm=jpg&fit=crop&w=1300&h=393.93939393939394&bg=f0f0f0&q=38&dpr=2",
+    "productImageUrls": [
+    "https://massdrop-s3.imgix.net/product-images/nitecore-ec22-1000-lumen-infinite-led-flashlight/FP/ymi3GLTpRR3l674PzWHB_page1.jpg?auto=format&fm=jpg&fit=crop&w=955&bg=f0f0f0&dpr=2", 
+    "https://massdrop-s3.imgix.net/product-images/nitecore-ec22-1000-lumen-infinite-led-flashlight/FP/N1jpcQzRTGunOpUNhE1J_qdQZJ0r.jpg?auto=format&fm=jpg&fit=crop&w=313&bg=f0f0f0&dpr=2", 
+    "https://massdrop-s3.imgix.net/product-images/nitecore-ec22-1000-lumen-infinite-led-flashlight/FP/JmR8zD6TG6zc88mQkW6x_ll0iIrKg.jpg?auto=format&fm=jpg&fit=crop&w=313&bg=f0f0f0&dpr=2", 
+    "https://massdrop-s3.imgix.net/product-images/nitecore-ec22-1000-lumen-infinite-led-flashlight/FP/5IeCUA3lQrq7pOJ2q1CJ_71a-JAdUymL._SL1280_.jpg?auto=format&fm=jpg&fit=crop&w=473&bg=f0f0f0&dpr=2", 
+    "https://massdrop-s3.imgix.net/product-images/nitecore-ec22-1000-lumen-infinite-led-flashlight/FP/5i35oRiSxeDlJT2Jrs2n_watermark.jpg?auto=format&fm=jpg&fit=crop&w=473&bg=f0f0f0&dpr=2", 
+    "https://massdrop-s3.imgix.net/product-images/nitecore-ec22-1000-lumen-infinite-led-flashlight/FP/c6icUJO7TbGowMXu3onU_TxTxLSa.jpg?auto=format&fm=jpg&fit=crop&w=313&bg=f0f0f0&dpr=2"
+  ]
   }
 }
 
 module.exports.giveMeHeadphones = (productName) => {
   return {
     "productName": productName,
-    "bannerImageUrl": "",
-	  "productImageUrls": ["", "", "", ""]
+    "bannerImageUrl": "https://massdrop-s3.imgix.net/product-images/massdrop-x-hifiman-edition-xx-headphones/FP/oPTmYvneR4mgwCXxVo8m_AI7B2574-copy-banner.jpg?auto=format&fm=jpg&fit=crop&w=1600&h=484.8484848484849&bg=f0f0f0&q=38&dpr=2",
+    "productImageUrls": [
+      "https://massdrop-s3.imgix.net/product-images/massdrop-x-hifiman-edition-xx-headphones/FP/XbUb57ecT9ydionwPeP5_AI7B2076-copy.jpg?auto=format&fm=jpg&fit=crop&w=955&bg=f0f0f0&dpr=2", 
+      "https://massdrop-s3.imgix.net/product-images/massdrop-x-hifiman-edition-xx-headphones/FP/MWs9iF0DTYekbci9Klb1_AI7B9691-copy.jpg?auto=format&fm=jpg&fit=crop&w=473&bg=f0f0f0&dpr=2", 
+      "https://massdrop-s3.imgix.net/product-images/massdrop-x-hifiman-edition-xx-headphones/FP/ZDXG4jirTL2QZjZKxa4X_AI7B9701-copy.jpg?auto=format&fm=jpg&fit=crop&w=473&bg=f0f0f0&dpr=2", 
+      "https://massdrop-s3.imgix.net/product-images/massdrop-x-hifiman-edition-xx-headphones/FP/oamINBMRTyiBVdaVjCry_AI7B9685-copy.jpg?auto=format&fm=jpg&fit=crop&w=955&bg=f0f0f0&dpr=2",
+      "https://massdrop-s3.imgix.net/product-images/massdrop-x-hifiman-edition-xx-headphones/FP/22WXXOstQNKjYnIb9mOG_AI7B9703-copy.jpg?auto=format&fm=jpg&fit=crop&w=473&bg=f0f0f0&dpr=2", 
+      "https://massdrop-s3.imgix.net/product-images/massdrop-x-hifiman-edition-xx-headphones/FP/n4qH0V56QVeSmO9BQzBL_AI7B9737-copy.jpg?auto=format&fm=jpg&fit=crop&w=473&bg=f0f0f0&dpr=2"
+    ]
   }
 }
 
 module.exports.giveMeKeyboard = (productName) => {
   return {
     "productName": productName,
-    "bannerImageUrl": "",
-	  "productImageUrls": ["", "", "", ""]
+    "bannerImageUrl": "https://massdrop-s3.imgix.net/product-images/planck-mechanical-keyboard/FP/Wle56GwdRgWPrbNaWRR7_AI7B6090-copy-banner.jpg?auto=format&fm=jpg&fit=crop&w=1600&h=484.8484848484849&bg=f0f0f0&q=38&dpr=2",
+	  "productImageUrls": [
+      "https://massdrop-s3.imgix.net/product-images/planck-mechanical-keyboard/FP/IhT3NhxzSAONgRhKbY7a_AI7B5534-copy.jpg?auto=format&fm=jpg&fit=crop&w=955&bg=f0f0f0&dpr=2", 
+      "https://massdrop-s3.imgix.net/product-images/planck-mechanical-keyboard/FP/cxWI1GyoSGGch6osWQrP_AI7B6777-copy.jpg?auto=format&fm=jpg&fit=crop&w=473&bg=f0f0f0&dpr=2", 
+      "https://massdrop-s3.imgix.net/product-images/planck-mechanical-keyboard/FP/ZOr1IE4RxuDmTVjv0gsJ_AI7B6804-copy.jpg?auto=format&fm=jpg&fit=crop&w=473&bg=f0f0f0&dpr=2", 
+      "https://massdrop-s3.imgix.net/product-images/planck-mechanical-keyboard/FP/XbWiNmBkQPqwVhk8EEMa_AI7B5416-copy-checkout1.jpg?auto=format&fm=jpg&fit=crop&w=473&bg=f0f0f0&dpr=2",
+      "https://massdrop-s3.imgix.net/product-images/planck-mechanical-keyboard/FP/Ew9RSUodQaCBRJ3KL1xM_AI7B5416-copy-checkout2.jpg?auto=format&fm=jpg&fit=crop&w=473&bg=f0f0f0&dpr=2",
+      "https://massdrop-s3.imgix.net/product-images/planck-mechanical-keyboard/FP/F9Q4Ma2YR0WVVKlLbu3C_AI7B5192-copy-pc-dark.jpg?auto=format&fm=jpg&fit=crop&w=955&bg=f0f0f0&dpr=2"
+    ]
   }
 }
 
 module.exports.giveMeSeki = (productName) => {
   return {
     "productName": productName,
-    "bannerImageUrl": "",
-	  "productImageUrls": ["", "", "", ""]
+    "bannerImageUrl": "https://massdrop-s3.imgix.net/product-images/seki-edge-grooming-kit/MD-26696_20160907100117_7a4ec8e1df101933.jpg?auto=format&fm=jpg&fit=crop&w=1300&h=393.93939393939394&bg=f0f0f0&q=38&dpr=2",
+	  "productImageUrls": [
+      "https://massdrop-s3.imgix.net/product-images/seki-edge-grooming-kit/MD-22295_20160630140124_2b713cd4c2a512bf.jpg?auto=format&fm=jpg&fit=crop&w=955&bg=f0f0f0&dpr=2", 
+      "https://massdrop-s3.imgix.net/product-images/seki-edge-grooming-kit/MD-22295_20160630140116_ae1e49ea4ed70295.jpg?auto=format&fm=jpg&fit=crop&w=473&bg=f0f0f0&dpr=2", 
+      "https://massdrop-s3.imgix.net/product-images/seki-edge-grooming-kit/MD-22295_20160630140120_9530bb0e7d7210ed.jpg?auto=format&fm=jpg&fit=crop&w=473&bg=f0f0f0&dpr=2", 
+      "https://massdrop-s3.imgix.net/product-images/seki-edge-grooming-kit/MD-22295_20160630140119_6ae07590600c9eb1.jpg?auto=format&fm=jpg&fit=crop&w=955&bg=f0f0f0&dpr=2", 
+      "https://massdrop-s3.imgix.net/product-images/seki-edge-grooming-kit/MD-22295_20160630140121_cf0b2f9b40987d9c.jpg?auto=format&fm=jpg&fit=crop&w=473&bg=f0f0f0&dpr=2", 
+      "https://massdrop-s3.imgix.net/product-images/seki-edge-grooming-kit/MD-22295_20160630140122_55bc1e6f8abdab8e.jpg?auto=format&fm=jpg&fit=crop&w=473&bg=f0f0f0&dpr=2",
+      "https://massdrop-s3.imgix.net/product-images/seki-edge-grooming-kit/MD-22295_20160630140121_6822ac4fc567f904.jpg?auto=format&fm=jpg&fit=crop&w=473&bg=f0f0f0&dpr=2",
+      "https://massdrop-s3.imgix.net/product-images/seki-edge-grooming-kit/MD-22295_20160630140121_cf0b2f9b40987d9c.jpg?auto=format&fm=jpg&fit=crop&w=473&bg=f0f0f0&dpr=2"
+    ]
   }
 }
 
 module.exports.giveMeWatches = (productName) => {
   return {
     "productName": productName,
-    "bannerImageUrl": "",
-	  "productImageUrls": ["", "", "", ""]
+    "bannerImageUrl": "https://massdrop-s3.imgix.net/product-images/glycine-combat-7-vintage-automatic-watch/MD-35241_20170307133651_61d31bad1fd919f0.jpg?auto=format&fm=jpg&fit=crop&w=1300&h=393.93939393939394&bg=f0f0f0&q=38&dpr=2",
+	  "productImageUrls": [
+      "https://massdrop-s3.imgix.net/product-images/glycine-combat-7-vintage-automatic-watch/MD-35241_20170314144456_2fce6411a07a1e77.jpg?auto=format&fm=jpg&fit=crop&w=955&bg=f0f0f0&dpr=2", 
+      "https://massdrop-s3.imgix.net/product-images/glycine-combat-7-vintage-automatic-watch/MD-35241_20170310104243_76ad41890b54249c.jpg?auto=format&fm=jpg&fit=crop&w=473&bg=f0f0f0&dpr=2", 
+      "https://massdrop-s3.imgix.net/product-images/glycine-combat-7-vintage-automatic-watch/MD-35241_20170310104242_81fcf644ff22679b.jpg?auto=format&fm=jpg&fit=crop&w=473&bg=f0f0f0&dpr=2", 
+      "https://massdrop-s3.imgix.net/product-images/glycine-combat-7-vintage-automatic-watch/MD-35241_20170310104242_3cbacbb3a05d7eb5.jpg?auto=format&fm=jpg&fit=crop&w=473&bg=f0f0f0&dpr=2"
+    ]
   }
 }
 
@@ -42,14 +77,22 @@ module.exports.giveMeCats = (productName) => {
   return {
     "productName": productName,
     "bannerImageUrl": "https://www.cats.org.uk/uploads/branches/1/42847%20Cats%20Weekly%20Lottery%20Web%20Banner.jpg",
-	  "productImageUrls": ["https://timedotcom.files.wordpress.com/2015/02/grumpy-cat1.jpg", 'https://images.pexels.com/photos/74177/cat-74177.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260', "https://timedotcom.files.wordpress.com/2015/02/grumpy-cat1.jpg", 'https://images.pexels.com/photos/74177/cat-74177.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260', "https://timedotcom.files.wordpress.com/2015/02/grumpy-cat1.jpg", 'https://images.pexels.com/photos/74177/cat-74177.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260']
+	  "productImageUrls": [
+      "https://timedotcom.files.wordpress.com/2015/02/grumpy-cat1.jpg", 
+      'https://images.pexels.com/photos/74177/cat-74177.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260', 
+      "https://timedotcom.files.wordpress.com/2015/02/grumpy-cat1.jpg", 
+      'https://images.pexels.com/photos/74177/cat-74177.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260', 
+      "https://timedotcom.files.wordpress.com/2015/02/grumpy-cat1.jpg", 
+      'https://images.pexels.com/photos/74177/cat-74177.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260'
+    ]
   }
 }
 
 module.exports.giveMeDogs = (productName) => {
   return {
     "productName": productName,
-    "bannerImageUrl": "",
-	  "productImageUrls": ["", "", "", ""]
+    "bannerImageUrl": "https://www.petconnectrescue.org/wp-content/uploads/2013/05/three-dogs-banner-e1500758981792.jpg",
+	  "productImageUrls": [
+    ]
   }
 }

--- a/server/testJson.js
+++ b/server/testJson.js
@@ -9,7 +9,7 @@ module.exports.giveMeFlashlight = (productName) => {
     "https://massdrop-s3.imgix.net/product-images/nitecore-ec22-1000-lumen-infinite-led-flashlight/FP/5IeCUA3lQrq7pOJ2q1CJ_71a-JAdUymL._SL1280_.jpg?auto=format&fm=jpg&fit=crop&w=473&bg=f0f0f0&dpr=2", 
     "https://massdrop-s3.imgix.net/product-images/nitecore-ec22-1000-lumen-infinite-led-flashlight/FP/5i35oRiSxeDlJT2Jrs2n_watermark.jpg?auto=format&fm=jpg&fit=crop&w=473&bg=f0f0f0&dpr=2", 
     "https://massdrop-s3.imgix.net/product-images/nitecore-ec22-1000-lumen-infinite-led-flashlight/FP/c6icUJO7TbGowMXu3onU_TxTxLSa.jpg?auto=format&fm=jpg&fit=crop&w=313&bg=f0f0f0&dpr=2"
-  ]
+    ]
   }
 }
 

--- a/server/testJson.js
+++ b/server/testJson.js
@@ -79,15 +79,14 @@ module.exports.giveMeCats = (productName) => {
     "bannerImageUrl": "https://www.cats.org.uk/uploads/branches/1/42847%20Cats%20Weekly%20Lottery%20Web%20Banner.jpg",
 	  "productImageUrls": [
       "https://timedotcom.files.wordpress.com/2015/02/grumpy-cat1.jpg", 
-      'https://images.pexels.com/photos/74177/cat-74177.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260', 
+      "https://images.pexels.com/photos/74177/cat-74177.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260", 
       "https://timedotcom.files.wordpress.com/2015/02/grumpy-cat1.jpg", 
-      'https://images.pexels.com/photos/74177/cat-74177.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260', 
+      "https://images.pexels.com/photos/74177/cat-74177.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260", 
       "https://timedotcom.files.wordpress.com/2015/02/grumpy-cat1.jpg", 
-      'https://images.pexels.com/photos/74177/cat-74177.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260'
+      "https://images.pexels.com/photos/74177/cat-74177.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260"
     ]
   }
 }
-
 module.exports.giveMeDogs = (productName) => {
   return {
     "productName": productName,

--- a/server/testJson.js
+++ b/server/testJson.js
@@ -1,7 +1,55 @@
+module.exports.giveMeFlashlight = (productName) => {
+  return {
+    "productName": productName,
+    "bannerImageUrl": "",
+	  "productImageUrls": ["", "", "", ""]
+  }
+}
+
+module.exports.giveMeHeadphones = (productName) => {
+  return {
+    "productName": productName,
+    "bannerImageUrl": "",
+	  "productImageUrls": ["", "", "", ""]
+  }
+}
+
+module.exports.giveMeKeyboard = (productName) => {
+  return {
+    "productName": productName,
+    "bannerImageUrl": "",
+	  "productImageUrls": ["", "", "", ""]
+  }
+}
+
+module.exports.giveMeSeki = (productName) => {
+  return {
+    "productName": productName,
+    "bannerImageUrl": "",
+	  "productImageUrls": ["", "", "", ""]
+  }
+}
+
+module.exports.giveMeWatches = (productName) => {
+  return {
+    "productName": productName,
+    "bannerImageUrl": "",
+	  "productImageUrls": ["", "", "", ""]
+  }
+}
+
 module.exports.giveMeCats = (productName) => {
   return {
     "productName": productName,
     "bannerImageUrl": "https://www.cats.org.uk/uploads/branches/1/42847%20Cats%20Weekly%20Lottery%20Web%20Banner.jpg",
 	  "productImageUrls": ["https://timedotcom.files.wordpress.com/2015/02/grumpy-cat1.jpg", 'https://images.pexels.com/photos/74177/cat-74177.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260', "https://timedotcom.files.wordpress.com/2015/02/grumpy-cat1.jpg", 'https://images.pexels.com/photos/74177/cat-74177.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260', "https://timedotcom.files.wordpress.com/2015/02/grumpy-cat1.jpg", 'https://images.pexels.com/photos/74177/cat-74177.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260']
+  }
+}
+
+module.exports.giveMeDogs = (productName) => {
+  return {
+    "productName": productName,
+    "bannerImageUrl": "",
+	  "productImageUrls": ["", "", "", ""]
   }
 }


### PR DESCRIPTION

![gallery 2](https://user-images.githubusercontent.com/1518509/47880064-a1253c00-ddf8-11e8-88d9-18042085a153.gif)



this update should not break any current implementation, but may display a 404 where static data used to be displayed

npm run seed now fills db with entries for final presentation, and ProductGallery is rendered to fetch the entries

the server now handles errors without crashing, and has /buy/:productName implemented as per our specification